### PR TITLE
Modify: optimize ChanneldConnection

### DIFF
--- a/Plugins/ChanneldUE/Source/ChanneldUE/ChanneldConnection.cpp
+++ b/Plugins/ChanneldUE/Source/ChanneldUE/ChanneldConnection.cpp
@@ -85,14 +85,16 @@ bool UChanneldConnection::Connect(bool bInitAsClient, const FString& Host, int P
 	bool bSocketConnected = Socket->Connect(*RemoteAddr);
 	if(!ensure(bSocketConnected))
 	{
+		Error = FString::Printf(TEXT("SocketConnected Faild"));
 		return false;
 	}
 	
-	if(ensure(StartReceiveThread()))
+	if(!ensure(StartReceiveThread()))
 	{
-		return true;
+		Error = FString::Printf(TEXT("Start receive thread Faild"));
+		return false;
 	}
-	return false;
+	return true;
 }
 
 void UChanneldConnection::Disconnect(bool bFlushAll/* = true*/)

--- a/Plugins/ChanneldUE/Source/ChanneldUE/ChanneldConnection.cpp
+++ b/Plugins/ChanneldUE/Source/ChanneldUE/ChanneldConnection.cpp
@@ -85,13 +85,13 @@ bool UChanneldConnection::Connect(bool bInitAsClient, const FString& Host, int P
 	bool bSocketConnected = Socket->Connect(*RemoteAddr);
 	if(!ensure(bSocketConnected))
 	{
-		Error = FString::Printf(TEXT("SocketConnected Faild"));
+		Error = FString::Printf(TEXT("SocketConnected failed"));
 		return false;
 	}
 	
 	if(!ensure(StartReceiveThread()))
 	{
-		Error = FString::Printf(TEXT("Start receive thread Faild"));
+		Error = FString::Printf(TEXT("Start receive thread failed"));
 		return false;
 	}
 	return true;
@@ -459,8 +459,9 @@ void UChanneldConnection::HandleSubToChannel(UChanneldConnection* Conn, ChannelI
 		}
 		else
 		{
-			channeldpb::SubscribedToChannelResultMessage ClonedSubMsg(*SubMsg);
-			SubscribedChannels.Add(ChId, &ClonedSubMsg);
+			channeldpb::SubscribedToChannelResultMessage* ClonedSubMsg = SubMsg->New();
+			ClonedSubMsg->CopyFrom(*SubMsg);
+			SubscribedChannels.Add(ChId, ClonedSubMsg);
 		}
 	}
 }

--- a/Plugins/ChanneldUE/Source/ChanneldUE/ChanneldConnection.h
+++ b/Plugins/ChanneldUE/Source/ChanneldUE/ChanneldConnection.h
@@ -81,7 +81,7 @@ public:
 		return ConnId;
 	}
 
-	FORCEINLINE bool IsConnected() { return !IsPendingKill() && Socket != nullptr && Socket->GetConnectionState() == SCS_Connected; }
+	FORCEINLINE bool IsConnected() { return !IsPendingKill() && Socket != nullptr && Socket->GetConnectionState() == SCS_Connected && bReceiveThreadRunning; }
 
 	FORCEINLINE channeldpb::ConnectionType GetConnectionType() { return ConnectionType; }
 


### PR DESCRIPTION
Unify the logic of the judgment of SocketConnect and StartReceiveThread in Connect.
IsConnected include bReceiveThreadRunning.